### PR TITLE
Allow to detect malicious secret service implementations

### DIFF
--- a/system/dbus.service
+++ b/system/dbus.service
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=org.freedesktop.secrets
-Exec=/usr/bin/python3 xikeyring
+Exec=/bin/false
 SystemdService=xi-keyring.service

--- a/system/systemd.service
+++ b/system/systemd.service
@@ -5,7 +5,7 @@ PartOf=graphical-session.target
 [Service]
 Type=dbus
 BusName=org.freedesktop.secrets
-ExecStart=/usr/bin/python3 -m xikeyring
+ExecStart=/usr/bin/python3 -I -m xikeyring
 MemoryDenyWriteExecute=yes
 NoNewPrivileges=yes
 ProtectSystem=strict

--- a/xikeyring/dbus.py
+++ b/xikeyring/dbus.py
@@ -11,6 +11,7 @@ from gi.repository import GLib
 from .dbus_sessions import create_session
 from .keyring import AccessDeniedError
 from .keyring import NotFoundError
+from .prompt import PinentryPrompt as Prompt
 
 OFSP = '/org/freedesktop/secrets'
 OFSI = 'org.freedesktop.Secret'
@@ -41,7 +42,10 @@ class BaseDBusService:
         print(f'bus {bus} acquired')
 
     def on_name_lost(self, conn, name, user_data=None):
-        sys.exit(f'Could not aquire name {name}. Is some other service blocking it?')
+        msg = f'Could not aquire name {name}. Is some other service blocking it?'
+        with Prompt() as prompt:
+            prompt.confirm(msg)
+        sys.exit(msg)
 
     def run(self, name):
         handle = Gio.bus_own_name(

--- a/xikeyring/kernel_keyring.py
+++ b/xikeyring/kernel_keyring.py
@@ -1,5 +1,6 @@
 import ctypes
 import os
+from weakref import finalize
 
 keyutils = ctypes.CDLL('libkeyutils.so.1')
 
@@ -29,11 +30,23 @@ def get_key(id: int, size: int) -> bytes:
     return buf.value
 
 
+def unlink_key(id: int, keyring: int):
+    print('unlink_key', id, keyring)
+    result = keyutils.keyctl_unlink(id, keyring)
+    if result == -1:
+        errno = ctypes.get_errno()
+        raise OSError(errno, os.strerror(errno))
+
+
 class KernelKey:
     def __init__(self, value: bytes, keyring: int = PROCESS_KEYRING):
         name = f'kernel-key-{id(self)}'.encode()
         self.id, self.size = add_key(name, value, keyring)
+        finalize(self, unlink_key, self.id, keyring)
 
     @property
     def value(self):
         return get_key(self.id, self.size)
+
+
+

--- a/xikeyring/prompt.py
+++ b/xikeyring/prompt.py
@@ -46,7 +46,7 @@ class PinentryPrompt:
         raise AssertionError('unreachable')
 
     def setup(self, title: str, desc: str):
-        self.call(b'SETTITLE ' + self.encode(title))
+        self.call(b'SETTITLE ' + self.encode('keyring'))
         self.call(b'SETPROMPT ' + self.encode(title))
         self.call(b'SETDESC ' + self.encode(desc))
         self.call(b'SETQUALITYBAR')


### PR DESCRIPTION
The whole idea of the project is to try to protect against malicious applications that have user permissions. Some of the ideas I have implemented so far are about the storage format (e.g. encrypted meta data). But most ideas (e.g. confirmation or namespacing) only affect the service. If an attacker manages to replace the service by a maliciously modified version, they can bypass all of those measures.

So how can we prevent attackers from replacing the implementation (or at least make it detectable)?

I have identified the following attacks and mitigations

- attack: trick the user into installing the malicious implementation
  - mitigation: the usual (too much to list it all)
- attack: acquire the dbus name before the real service
  - mitigation: warn the user if the name could not be acquired
- attack: provide a python module with the same name in a high-priority path
  - mitigation: use `python -I` to restrict the path to locations that are not writable by the user
- attack: disable the systemd service and replace it with your own
  - mitigation: ???

With most of these attacks, a command like `pgrep -af xikeyring` lets you discover whether the real implementation is currently running. But you have to do this yourself. Any automated process would have the same issue in that it could be replaced by a malicious implementation.

The same is true for personalization: An attacker cannot easily impersonate your implementation if it is one of a kind and easily recognizable to you. But this also cannot be generalized because if the personalization is done via a config file, the attacker can read that config.

We come back to the same question: Is all of this pointless security theater because there are just too many ways to replace the implementation? Or do the individual mitigations still add value?

Given that malicious implementations *can be detected* (even though it needs to be done by manual checks) I think that not everything is lost. Mitigations can make it easier to detect malicious implementations by restricting the possible attacks to few well known cases.

But it also needs to be clear that attacks are still possible. Mitigations that add too much complexity (for developers or users) should be avoided if they cannot ultimately prevent attacks.