### PR TITLE
app_id: use pidfd to protect against data races

### DIFF
--- a/xikeyring/app_id.py
+++ b/xikeyring/app_id.py
@@ -1,13 +1,21 @@
 import configparser
+import selectors
 from pathlib import Path
 
 
-def get_app_id(pid: int) -> str:
+def get_app_id(pid: int, pidfd: int) -> str:
     path = Path('/proc') / str(pid) / 'root' / '.flatpak-info'
     config = configparser.ConfigParser()
     try:
         with path.open() as fh:
             config.read_file(fh)
-        return config['Application']['name']
+        app_id = config['Application']['name']
     except Exception:
         return ''
+
+    with selectors.DefaultSelector() as sel:
+        sel.register(pidfd, selectors.EVENT_READ)
+        if sel.select() != []:
+            raise ValueError('Calling process has quit')
+
+    return app_id

--- a/xikeyring/dbus.py
+++ b/xikeyring/dbus.py
@@ -116,18 +116,18 @@ class BaseDBusService:
         return True
 
     def get_app_id(self, conn, sender) -> str:
-        pid = conn.call_sync(
+        cred = conn.call_sync(
             'org.freedesktop.DBus',
             '/org/freedesktop/DBus',
             'org.freedesktop.DBus',
-            'GetConnectionUnixProcessID',
+            'GetConnectionCredentials',
             GLib.Variant('(s)', [sender]),
-            GLib.VariantType('(u)'),
+            GLib.VariantType('(a{sv})'),
             Gio.DBusCallFlags.NONE,
             -1,
             None,
         )[0]
-        return get_app_id(pid)
+        return get_app_id(cred['ProcessID'], cred['ProcessFD'])
 
 
 class DBusService(BaseDBusService):


### PR DESCRIPTION
split from #5 

see https://github.com/swaywm/sway/pull/3088#issuecomment-456078987 for examples of possible attacks

Issue: `ProcessFD` is always 0 when running as a systemd user service. No idea why.